### PR TITLE
Implement regex to match excluded file paths

### DIFF
--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -110,14 +110,21 @@ function rt_scripts_handler( $tag, $handle, $src ) {
 
 	// Get handle using the paths provided in the settings.
 	foreach ( $paths_option_array as $key => $script_path ) {
-		$script_path = trim( $script_path );
+		$script_path = trim( $script_path, '/' );
 		if ( empty( $script_path ) ) {
 			continue;
 		}
 
-		if ( strpos( $src, $script_path ) && ! in_array( $handle, $skip_js, true ) ) {
-			array_push( $skip_js, $handle );
-			break;
+		$regex_pattern = get_site_url();
+
+		$regex_pattern = escape_regex_special_characters( $regex_pattern . '/' . $script_path );
+
+		$regex_pattern = $regex_pattern . '(\/?|\/?\?((([a-zA-Z0-9\%.]+=[a-zA-Z0-9\%.]+)(\&([a-zA-Z0-9\%.]+=[a-zA-Z0-9\%.]+))*)\&?)?)' . '$';
+
+		$regex_pattern = '/' . $regex_pattern . '/';
+
+		if ( preg_match( $regex_pattern, $src ) ) {
+			return $tag;
 		}
 	}
 
@@ -186,4 +193,18 @@ function disable_emojis_remove_dns_prefetch( $urls, $relation_type ) {
 		$urls = array_diff( $urls, array( $emoji_svg_url ) );
 	}
 	return $urls;
+}
+
+/**
+ * Escapes regex reserved characters.
+ *
+ * @param string $unescaped_value value whose regex characters are to be escaped.
+ *
+ * @return string Regex characters escaped string.
+ */
+function escape_regex_special_characters( $unescaped_value ) {
+	$escaped_value = str_replace( '/', '\/', $unescaped_value );
+	$escaped_value = str_replace( '.', '\.', $escaped_value );
+	$escaped_value = str_replace( '$', '\$', $escaped_value );
+	return $escaped_value;
 }


### PR DESCRIPTION
## Issue:
#12 

## Resolution applied in short:

The excluded file paths option should be matched against the resource URL through a regex expression. And if a match happens then that resource should be excluded from optimization.
- So, suppose in the options page someone supplies this value as a path - `/wp-includes/js/jquery/jquery.min.js`.
  ![Screenshot_20220418_140648](https://user-images.githubusercontent.com/39427067/163781703-20cbb769-eb64-46be-bacc-b9bf8451684f.png)
- Now in the backend, i.e during applying the optimization step of the script tags, a regex will be formed like this for the above value
  ```
  /http:\/\/rtcamp\.lndo\.site\/wp-includes\/js\/jquery\/jquery\.min\.js(\/?|\/?\?((([a-zA-Z0-9\%.]+=[a-zA-Z0-9\%.]+)(\&([a-zA-Z0-9\%.]+=[a-zA-Z0-9\%.]+))*)\&?)?)$/
  ```
- Now that regex will be matched with the resource URL of the script tag.
- If a match happens then that script tag will not be optimized, i.e rendered in the usual way. And if the match doesn't happen then only the optimization will be applied.
The same thing happens for all comma-separated path values.
